### PR TITLE
[review] feat: update mcp gem to ~> 0.15

### DIFF
--- a/copy_tuner_client-mcp.gemspec
+++ b/copy_tuner_client-mcp.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new depende
   spec.add_dependency "copy_tuner_client", ">= 1.0.0"
-  spec.add_dependency "mcp", ">= 0.8.0"
+  spec.add_dependency "mcp", "~> 0.15"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/exe/copy-tuner-mcp
+++ b/exe/copy-tuner-mcp
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "mcp"
-require "mcp/transports/stdio"
+require "mcp/server/transports/stdio_transport"
 require_relative "../lib/copy_tuner_client/mcp"
 
 require File.expand_path(File.join("config", "environment"))
@@ -46,5 +46,5 @@ server.resources_read_handler do |params|
   end
 end
 
-transport = MCP::Transports::StdioTransport.new(server)
+transport = MCP::Server::Transports::StdioTransport.new(server)
 transport.open

--- a/lib/copy_tuner_client/mcp/version.rb
+++ b/lib/copy_tuner_client/mcp/version.rb
@@ -2,6 +2,6 @@
 
 module CopyTunerClient
   module Mcp
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
## Summary

- `MCP::Transports` モジュールが v0.15.0 で削除されたため ([#331](https://github.com/modelcontextprotocol/ruby-sdk/pull/331))、Transport の require パスとクラス名を新 namespace に更新
- gemspec の依存制約を `>= 0.8.0` から `~> 0.15` に変更
- バージョンを 0.5.0 に bump

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `exe/copy-tuner-mcp` | `require "mcp/transports/stdio"` | `require "mcp/server/transports/stdio_transport"` |
| `exe/copy-tuner-mcp` | `MCP::Transports::StdioTransport` | `MCP::Server::Transports::StdioTransport` |
| `copy_tuner_client-mcp.gemspec` | `>= 0.8.0` | `~> 0.15` |

## 調査結果

Tool クラスレベル（全 5 ファイル）の API は v0.15.0 で完全互換のため、`lib/` と `spec/` への変更は不要でした。

## Test plan

- [x] `bundle exec rake spec` — 12 examples, 0 failures
- [x] Transport / Server / ResourceTemplate / resources_read_handler の smoke test 通過
- [x] `initialize` + `tools/list` の JSON-RPC レスポンスで 5 ツール全件登録確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)