### PR TITLE
[review] feat: create_i18n_key を同期一括登録API に移行

### DIFF
--- a/lib/copy_tuner_client/mcp/api_client.rb
+++ b/lib/copy_tuner_client/mcp/api_client.rb
@@ -25,12 +25,13 @@ module CopyTunerClient
         SocketError, OpenSSL::SSL::SSLError, Errno::ECONNREFUSED
       ].freeze
 
-      # 1 件以上のドラフト blurb をローカライズデータとともに一括作成する。
+      # 1 件以上のドラフト blurb をローカライズデータとともに同期で一括作成する。
+      # DB 登録は同期で行いバリデーションエラーを即座に返す。S3 反映のみ非同期ジョブに委譲される。
       # @param blurbs [Array<Hash>] e.g. [{ key:, localizations: { "ja" => "..." } }]
       # @return [Hash] parsed response body
       # @raise [ApiError] on a non-success response
-      def create_bulk_draft_blurbs(blurbs)
-        request(Net::HTTP::Post.new("#{API_BASE_PATH}/bulk_draft_blurbs"), { blurbs: blurbs })
+      def create_sync_bulk_draft_blurbs(blurbs)
+        request(Net::HTTP::Post.new("#{API_BASE_PATH}/sync_bulk_draft_blurbs"), { blurbs: blurbs })
       end
 
       # 既存の blurb のドラフトローカライズデータを更新する。

--- a/lib/copy_tuner_client/mcp/tool/create_i18n_key.rb
+++ b/lib/copy_tuner_client/mcp/tool/create_i18n_key.rb
@@ -13,8 +13,11 @@ module CopyTunerClient
         tool_name "create_i18n_key"
         description "Create a new Rails i18n translation key in the copy_tuner project. " \
                     "Registers a draft key with translations for one or more locales via the CopyTuner API. " \
-                    "Note: the key is processed asynchronously on the server and may not be immediately " \
-                    "visible to clients. Publishing happens separately on the CopyTuner side."
+                    "The key is created synchronously, so validation errors (e.g. the key already exists or " \
+                    "the locale count limit is exceeded) are returned immediately. " \
+                    "Note: this endpoint is for initial registration only and rejects existing keys. " \
+                    "The created draft is not immediately visible to clients because cache (S3) refresh " \
+                    "happens asynchronously, and publishing happens separately on the CopyTuner side."
         input_schema(
           properties: {
             key: { type: "string", description: "The i18n key to register" },
@@ -40,7 +43,7 @@ module CopyTunerClient
           def call(key:, translations:, server_context:) # rubocop:disable Lint/UnusedMethodArgument
             # NOTE: 同一キーの複数言語はcopytunerの仕様上同時に登録する必要がある
             run_i18n_tool(key: key, translations: translations, verb: "Created") do |loc|
-              ApiClient.new.create_bulk_draft_blurbs([{ key: key, localizations: loc }])
+              ApiClient.new.create_sync_bulk_draft_blurbs([{ key: key, localizations: loc }])
             end
           end
         end

--- a/spec/copy_tuner_client/mcp/api_client_spec.rb
+++ b/spec/copy_tuner_client/mcp/api_client_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe CopyTunerClient::Mcp::ApiClient do
     response
   end
 
-  describe "#create_bulk_draft_blurbs" do
+  describe "#create_sync_bulk_draft_blurbs" do
     let(:blurbs) do
       [{ key: "greeting.hello", localizations: { "ja" => "こんにちは", "en" => "Hello" } }]
     end
 
-    it "POSTs to /api/v3/bulk_draft_blurbs with bearer auth and json body" do
+    it "POSTs to /api/v3/sync_bulk_draft_blurbs with bearer auth and json body" do
       captured = {}
       allow(http).to receive(:request) do |request|
         captured[:method] = request.method
@@ -51,10 +51,10 @@ RSpec.describe CopyTunerClient::Mcp::ApiClient do
         stub_response(Net::HTTPCreated, '{"message":"Draft blurbs created successfully"}')
       end
 
-      result = described_class.new.create_bulk_draft_blurbs(blurbs)
+      result = described_class.new.create_sync_bulk_draft_blurbs(blurbs)
 
       expect(captured[:method]).to eq("POST")
-      expect(captured[:path]).to eq("/api/v3/bulk_draft_blurbs")
+      expect(captured[:path]).to eq("/api/v3/sync_bulk_draft_blurbs")
       expect(captured[:authorization]).to eq("Bearer test-api-key")
       expect(captured[:content_type]).to eq("application/json")
       expect(JSON.parse(captured[:body])).to eq(
@@ -65,13 +65,18 @@ RSpec.describe CopyTunerClient::Mcp::ApiClient do
       expect(result["message"]).to eq("Draft blurbs created successfully")
     end
 
-    it "raises ApiError with server messages on 422" do
+    it "raises ApiError with the message and errors array on 422" do
+      body = '{"message":"Failed to create draft blurbs.",' \
+             '"errors":["Blurb \'greeting.hello\' already exists."]}'
       allow(http).to receive(:request).and_return(
-        stub_response(Net::HTTPUnprocessableEntity, '{"message":"Locale count limit over."}')
+        stub_response(Net::HTTPUnprocessableEntity, body)
       )
 
-      expect { described_class.new.create_bulk_draft_blurbs(blurbs) }
-        .to raise_error(CopyTunerClient::Mcp::ApiError, /Locale count limit over\./)
+      expect { described_class.new.create_sync_bulk_draft_blurbs(blurbs) }
+        .to raise_error(
+          CopyTunerClient::Mcp::ApiError,
+          /Failed to create draft blurbs\..*Blurb 'greeting\.hello' already exists\./
+        )
     end
 
     it "raises ApiError on 401" do
@@ -79,7 +84,7 @@ RSpec.describe CopyTunerClient::Mcp::ApiClient do
         stub_response(Net::HTTPUnauthorized, '{"error":"Invalid API key."}')
       )
 
-      expect { described_class.new.create_bulk_draft_blurbs(blurbs) }
+      expect { described_class.new.create_sync_bulk_draft_blurbs(blurbs) }
         .to raise_error(CopyTunerClient::Mcp::ApiError, /Invalid API key\./)
     end
   end

--- a/spec/copy_tuner_client/mcp/tool/create_i18n_key_spec.rb
+++ b/spec/copy_tuner_client/mcp/tool/create_i18n_key_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe CopyTunerClient::Mcp::Tool::CreateI18nKey do
 
     before do
       allow(CopyTunerClient::Mcp::ApiClient).to receive(:new).and_return(api_client)
-      allow(api_client).to receive(:create_bulk_draft_blurbs)
+      allow(api_client).to receive(:create_sync_bulk_draft_blurbs)
         .and_return({ "message" => "Draft blurbs created successfully" })
     end
 
     it "creates a bulk draft blurb with localizations for multiple locales" do
       response = described_class.call(key: key, translations: translations, server_context: server_context)
 
-      expect(api_client).to have_received(:create_bulk_draft_blurbs).with(
+      expect(api_client).to have_received(:create_sync_bulk_draft_blurbs).with(
         [{ key: key, localizations: { "ja" => "新しいテストキー", "en" => "New Test Key" } }]
       )
 
@@ -39,14 +39,14 @@ RSpec.describe CopyTunerClient::Mcp::Tool::CreateI18nKey do
 
       response = described_class.call(key: key, translations: single_translation, server_context: server_context)
 
-      expect(api_client).to have_received(:create_bulk_draft_blurbs).with(
+      expect(api_client).to have_received(:create_sync_bulk_draft_blurbs).with(
         [{ key: key, localizations: { "ja" => "単一ロケール" } }]
       )
       expect(response.error?).to be(false)
     end
 
     it "returns an error response when the API call fails" do
-      allow(api_client).to receive(:create_bulk_draft_blurbs)
+      allow(api_client).to receive(:create_sync_bulk_draft_blurbs)
         .and_raise(CopyTunerClient::Mcp::ApiError, "Locale count limit over.")
 
       response = described_class.call(key: key, translations: translations, server_context: server_context)


### PR DESCRIPTION
<!-- pr-summary-start -->
## 背景・課題

`create_i18n_key` ツールは、これまで非同期エンドポイント `/api/v3/bulk_draft_blurbs` を呼んで i18n キーを draft 登録していた。このエンドポイントは登録ジョブをキューに積むだけで即座に成功レスポンスを返すため、「既存キーとの重複」「ロケール数の上限超過」といったバリデーションエラーがレスポンスに乗らなかった。結果として、MCP クライアント（AIアシスタント）側は登録が実際には失敗していても検知できず、成功したと誤認してしまう問題があった。

copy-tuner 側の [PR #1894](https://github.com/SonicGarden/copy-tuner/pull/1894) で、DB 登録を同期的に行いバリデーション結果を即返す新エンドポイント `/api/v3/sync_bulk_draft_blurbs` が追加された。本 PR はこれに乗り換えて、登録失敗をクライアントが即座に検知できるようにする。

## 変更内容

- **エンドポイントの移行**: `ApiClient#create_bulk_draft_blurbs`（非同期 `/bulk_draft_blurbs`）を `create_sync_bulk_draft_blurbs`（同期 `/sync_bulk_draft_blurbs`）にリネーム＋差し替え。`create_i18n_key` ツールの呼び出し箇所も追従。
- **ツール description の更新**: 同期登録によりバリデーションエラーが即返ることを明記。同時に「このエンドポイントは新規登録専用で既存キーは拒否する」点も追記。一方で、DB 登録は同期でも **S3（キャッシュ）反映は非同期ジョブのまま**であり、登録直後は読み取り系ツールにまだ反映されない点は従来通り残している（同期化されたのは DB 登録のみ、という線引きが意図的に維持されている）。
- **spec の強化**: メソッド名・パスの更新に加え、422 ケースのテストを実際のレスポンス形式（`message` + `errors` 配列）に合わせて検証するよう強化。従来は単一の `message` 文字列のみを確認していた。

設計判断として、非同期 API を残したまま新メソッドを足すのではなく**既存メソッドを置き換える形**を選んでいる。`create_i18n_key` は新規登録専用ツールであり、エラーを即検知できる同期版に一本化するのが目的に適うため。

## レビューのポイント

- **ツール description の文言が AI の挙動を左右する**: このツールの利用者は AI アシスタントであり、description が実質的な「仕様書」として機能する。「新規登録専用・既存キーは拒否」「登録後すぐには読み取りに反映されない」という2つの制約が正しく伝わり、AI が誤って既存キーに対してこのツールを呼ばないか（本来は `update_i18n_key` を使うべき）という観点での確認が有効。
- **422 エラーが MCP クライアントにどう見えるか**: 同期化の目的はエラーの即時検知。`ApiError`（`message` + `errors`）が最終的に MCP の `Response` としてユーザー/AI にどう表示されるかを確認しておくと、移行の意図が達成されているか判断できる。
- **サーバー側エンドポイントのデプロイ順序**: 本 PR は copy-tuner PR #1894 の `/sync_bulk_draft_blurbs` 提供が前提。サーバー側が先にデプロイされていないと、このクライアントは存在しないパスを叩いて失敗する。リリース順序の調整が必要かどうかは要確認。
<!-- pr-summary-end -->
